### PR TITLE
zip all handler files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev-watch:
 HANDLERS=$(addsuffix main.zip,$(wildcard handlers/*/))
 handlers: $(HANDLERS)
 $(HANDLERS): handlers/%/main.zip: *.go handlers/%/main.go
-	cd ./$(dir $@) && GOOS=linux go build -o main . && zip -1 main.zip main
+	cd ./$(dir $@) && GOOS=linux go build -o main . && zip -1 main.zip *
 
 test:
 	go test -v ./...


### PR DESCRIPTION
It is useful to add additional files into the .zip package, like binaries and libraries. So might as well zip of everything in the handler directory.

```console
$ ls handlers/postgrest/
libpq.so.5 main       main.go    main.zip   postgrest
```